### PR TITLE
Fix function name,  Raise NotImplementedError, Update spectrometers.py

### DIFF
--- a/seabreeze/cseabreeze/__init__.py
+++ b/seabreeze/cseabreeze/__init__.py
@@ -54,7 +54,7 @@ from .wrapper import (SeaBreezeError,
                       nonlinearity_coeffs_get,
                       stray_light_coeffs_get,
                       device_get_spectrum_processing_feature_id,
-                      spectrometer_set_boxcar_width,
-                      spectrometer_set_scans_to_average,
-                      spectrometer_get_boxcar_width,
-                      spectrometer_get_scans_to_average)
+                      spectrum_processing_set_boxcar_width,
+                      spectrum_processing_set_scans_to_average,
+                      spectrum_processing_get_boxcar_width,
+                      spectrum_processing_get_scans_to_average)

--- a/seabreeze/cseabreeze/wrapper.pyx
+++ b/seabreeze/cseabreeze/wrapper.pyx
@@ -629,21 +629,21 @@ def device_get_spectrum_processing_feature_id(SeaBreezeDevice device not None):
                 "%d tec features. The code expects it to have 0 or 1. "
                 "Please file a bug report including a description of your device." % N)
 
-def spectrometer_set_boxcar_width(SeaBreezeDevice device not None, long featureID, unsigned char boxcar_width):
+def spectrum_processing_set_boxcar_width(SeaBreezeDevice device not None, long featureID, unsigned char boxcar_width):
     cdef int error_code
     with nogil:
         csb.sbapi_spectrum_processing_boxcar_width_set(device.handle, featureID, &error_code, boxcar_width)
     if error_code != 0:
         raise SeaBreezeError(error_code=error_code)
     
-def spectrometer_set_scans_to_average(SeaBreezeDevice device not None, long featureID, unsigned short int scans_to_average):
+def spectrum_processing_set_scans_to_average(SeaBreezeDevice device not None, long featureID, unsigned short int scans_to_average):
     cdef int error_code
     with nogil:
         csb.sbapi_spectrum_processing_scans_to_average_set(device.handle, featureID, &error_code, scans_to_average)
     if error_code != 0:
         raise SeaBreezeError(error_code=error_code)
 
-def spectrometer_get_boxcar_width(SeaBreezeDevice device not None, long featureID):
+def spectrum_processing_get_boxcar_width(SeaBreezeDevice device not None, long featureID):
     cdef unsigned char boxcar_width
     cdef int error_code
     with nogil:
@@ -652,7 +652,7 @@ def spectrometer_get_boxcar_width(SeaBreezeDevice device not None, long featureI
         raise SeaBreezeError(error_code=error_code)
     return boxcar_width   
 
-def spectrometer_get_scans_to_average(SeaBreezeDevice device not None, long featureID):
+def spectrum_processing_get_scans_to_average(SeaBreezeDevice device not None, long featureID):
     cdef unsigned short int scans_to_average
     cdef int error_code
     with nogil:

--- a/seabreeze/pyseabreeze/__init__.py
+++ b/seabreeze/pyseabreeze/__init__.py
@@ -52,4 +52,9 @@ from .wrapper import (SeaBreezeError,
                       tec_set_enable,
                       lamp_set_lamp_enable,
                       nonlinearity_coeffs_get,
-                      stray_light_coeffs_get)
+                      stray_light_coeffs_get,
+                      device_get_spectrum_processing_feature_id,
+                      spectrum_processing_set_boxcar_width,
+                      spectrum_processing_set_scans_to_average,
+                      spectrum_processing_get_boxcar_width,
+                      spectrum_processing_get_scans_to_average)

--- a/seabreeze/pyseabreeze/wrapper.py
+++ b/seabreeze/pyseabreeze/wrapper.py
@@ -292,3 +292,19 @@ def stray_light_coeffs_get(device, has_feature):
         raise SeaBreezeError("Error: No such feature on device")
     raise NotImplementedError
 
+# SPECTRUM PROCESSING
+
+def device_get_spectrum_processing_feature_id(SeaBreezeDevice device not None):
+    raise NotImplementedError
+
+def spectrum_processing_set_boxcar_width(SeaBreezeDevice device not None, long featureID, unsigned char boxcar_width):
+    raise NotImplementedError
+    
+def spectrum_processing_set_scans_to_average(SeaBreezeDevice device not None, long featureID, unsigned short int scans_to_average):
+    raise NotImplementedError
+
+def spectrum_processing_get_boxcar_width(SeaBreezeDevice device not None, long featureID):
+    raise NotImplementedError  
+
+def spectrum_processing_get_scans_to_average(SeaBreezeDevice device not None, long featureID):
+    raise NotImplementedError

--- a/seabreeze/spectrometers.py
+++ b/seabreeze/spectrometers.py
@@ -103,7 +103,7 @@ class Spectrometer(object):
         self._fidte = feature.add('tec')
         self._fidnc = feature.add('nonlinearity_coeffs')  # Added
         self._fidsl = feature.add('stray_light_coeffs')
-        self._fidspp = feature.add('spectrum_processing')
+        self._fidspp = feature.add('spectrum_processing') # Not implemented in pyseabreeze
         # get additional information
         self._pixels = lib.spectrometer_get_formatted_spectrum_length(self._dev, self._fidsp)
         self._minimum_integration_time_micros = (
@@ -170,12 +170,19 @@ class Spectrometer(object):
 
     def trigger_mode(self, mode):
         lib.spectrometer_set_trigger_mode(self._dev, self._fidsp, mode)
-        
+
     def boxcar_width(self, boxcar_width):
-        lib.spectrometer_set_boxcar_width(self._dev, self._fidspp, boxcar_width)
+        lib.spectrum_processing_set_boxcar_width(self._dev, self._fidspp, boxcar_width) # Not implemented in pyseabreeze
 
     def scans_to_average(self, scans_to_average):
-        lib.spectrometer_set_scans_to_average(self._dev, self._fidspp, scans_to_average)
+        lib.spectrum_processing_set_scans_to_average(self._dev, self._fidspp, scans_to_average) # Not implemented in pyseabreeze
+
+    def get_boxcar_width(self):
+        lib.spectrum_processing_get_boxcar_width(self._dev, self._fidspp) # Not implemented in pyseabreeze
+
+    def get_scans_to_average(self):
+        lib.spectrum_processing_get_scans_to_average(self._dev, self._fidspp) # Not implemented in pyseabreeze
+
 
     @property
     def serial_number(self):


### PR DESCRIPTION
fix the name of spectrum_processing_* functions
last added spectrometer_* functions in cseabreeze.pyx have been prefixed with spectrum_processing_ .

raise NotImplementedError
The spectrum_processing_* functions added in cseabreeze backend have been edited in pyseabreeze backend ,and all these raise an NotImplementedError.

Update spectrometers.py
Update spectrometers.py after newly spectrometer_* functions in cseabreeze.pyx been prefixed with spectrum_processing_ instead of spectrometer_.